### PR TITLE
Add dockerignore for PrivateGPT image

### DIFF
--- a/privategpt/.dockerignore
+++ b/privategpt/.dockerignore
@@ -1,0 +1,4 @@
+*/
+.git
+*.md
+tests/


### PR DESCRIPTION
## Summary
- Reduce Docker build context for PrivateGPT by adding a .dockerignore

## Testing
- `docker build -t privategpt-test privategpt` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a965cfff5083338fb0942270aac939