### PR TITLE
Fix tftpd-hpa workflow version output

### DIFF
--- a/.github/workflows/tftpd-hpa.yml
+++ b/.github/workflows/tftpd-hpa.yml
@@ -47,8 +47,9 @@ jobs:
         id: tag
         run: |
           docker build -t 3x3cut0r/tftpd-hpa:latest ./tftpd-hpa
-          VERSION=$(docker run --rm 3x3cut0r/tftpd-hpa:latest sh -c "cat /VERSION | grep tftpd-hpa | cut -d= -f2")
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(docker run --rm 3x3cut0r/tftpd-hpa:latest \
+            sh -c 'grep tftpd-hpa /VERSION | cut -d= -f2')
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # https://github.com/docker/build-push-action
       - name: Build and push


### PR DESCRIPTION
## Summary
- ensure the tftpd-hpa workflow writes version output in the expected name=value format
- quote GITHUB_OUTPUT usage

## Testing
- `yamllint .github/workflows/tftpd-hpa.yml`

------
https://chatgpt.com/codex/tasks/task_e_68ad2f8725a48333b5b5196d91b95f3c