### PR TITLE
Add version output for 404 image

### DIFF
--- a/404/Dockerfile
+++ b/404/Dockerfile
@@ -73,7 +73,12 @@ ENV TZ="UTC" \
     WOMAN_SHOE_RIGHT_TOP="white" \
     WOMAN_FLASHLIGHT="#2F1829" \
     WOMAN_FLASHLIGHT_NEAR="white" \
-    WOMAN_FLASHLIGHT_FAR="white" 
+    WOMAN_FLASHLIGHT_FAR="white"
+
+# Store versions in /VERSION
+RUN touch /VERSION && \
+    echo "alpine=$(cat /etc/alpine-release)" > /VERSION && \
+    echo "nginx=$(nginx -v 2>&1 | cut -d/ -f2)" >> /VERSION
 
 VOLUME /usr/share/nginx/html
 WORKDIR /usr/share/nginx/html

--- a/404/docker-entrypoint.sh
+++ b/404/docker-entrypoint.sh
@@ -12,6 +12,9 @@ cp /usr/share/nginx/template/js/script.js /usr/share/nginx/html/js/script.js
 # TIMEZONE
 ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# print version
+cat /VERSION
+
 # TITLE
 sed -i "9s/.*/\ \ \ \ <title>${TITLE}<\/title>/" /usr/share/nginx/html/index.html
 


### PR DESCRIPTION
## Summary
- Store base image and nginx versions in the 404 container
- Print version information at startup

## Testing
- `docker build -t test-404 .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3314cd108333a1a36a72278cf340