### PR TITLE
fix: sanitize tftp-hpa version output

### DIFF
--- a/.github/workflows/tftpd-hpa.yml
+++ b/.github/workflows/tftpd-hpa.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           docker build -t 3x3cut0r/tftpd-hpa:latest ./tftpd-hpa
           VERSION=$(docker run --rm 3x3cut0r/tftpd-hpa:latest \
-            sh -c 'grep tftpd-hpa /VERSION | cut -d= -f2')
+            sh -c "grep tftpd-hpa /VERSION | cut -d= -f2 | tr -d '\\r\\n'")
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
## Summary
- ensure tftpd-hpa workflow writes clean VERSION output to GITHUB_OUTPUT

## Testing
- `yamllint .github/workflows/tftpd-hpa.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b0ac3792488333be99ed04be518b71