### PR TITLE
fix: sanitize tftp-hpa version output

### DIFF
--- a/.github/workflows/tftpd-hpa.yml
+++ b/.github/workflows/tftpd-hpa.yml
@@ -47,8 +47,8 @@ jobs:
         id: tag
         run: |
           docker build -t 3x3cut0r/tftpd-hpa:latest ./tftpd-hpa
-          VERSION=$(docker run --rm 3x3cut0r/tftpd-hpa:latest \
-            sh -c 'grep tftpd-hpa /VERSION | cut -d= -f2')
+          VERSION=$(docker run --rm --entrypoint '' 3x3cut0r/tftpd-hpa:latest \
+            sh -c "grep tftpd-hpa /VERSION | cut -d= -f2 | tr -d '\\r\\n'")
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
## Summary
- ensure tftpd-hpa workflow writes clean VERSION output to GITHUB_OUTPUT by running container without entrypoint

## Testing
- `yamllint .github/workflows/tftpd-hpa.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b0ac3792488333be99ed04be518b71