### PR TITLE
Fix conda solver configuration in whisper-gui Dockerfile

### DIFF
--- a/whisper-gui/Dockerfile
+++ b/whisper-gui/Dockerfile
@@ -24,6 +24,7 @@ SHELL ["bash", "-c"]
 RUN conda create --name whisper-gui python=3.10 -y && \
     conda clean -a -y && \
     conda update -n base -c conda-forge -c pytorch conda && \
+    conda config --set solver classic && \
     echo "conda activate whisper-gui" >> ~/.bashrc && \
     source /opt/conda/etc/profile.d/conda.sh -y && \
     conda activate whisper-gui && \


### PR DESCRIPTION
## Summary
- configure conda to use the classic solver during the whisper-gui image build to avoid libmamba plugin import errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb353dbbc833391767983663f8cd5