### PR TITLE
Fix Whisper GUI container dependency issues

### DIFF
--- a/whisper-gui/Dockerfile
+++ b/whisper-gui/Dockerfile
@@ -25,13 +25,14 @@ RUN conda create --name whisper-gui python=3.10 -y && \
     conda clean -a -y && \
     conda update -n base -c conda-forge -c pytorch conda && \
     conda config --set solver classic && \
+    conda remove -n base conda-libmamba-solver -y && \
     echo "conda activate whisper-gui" >> ~/.bashrc && \
     source /opt/conda/etc/profile.d/conda.sh -y && \
     conda activate whisper-gui && \
     conda install -c conda-forge -c pytorch \
         "numpy<2" \
-        pytorch==2.0.1 \
-        torchaudio==2.0.2 \
+        pytorch==2.1.2 \
+        torchaudio==2.1.2 \
         cpuonly && \
     printf "numpy<2\n" > /tmp/pip_constraints.txt && \
     PIP_CONSTRAINT=/tmp/pip_constraints.txt pip install \
@@ -86,6 +87,32 @@ if 'additional_props = schema["additionalProperties"]' not in text:
     text = text.replace(additional_guard, additional_replacement)
 
 path.write_text(text)
+PY
+    python - <<'PY'
+from pathlib import Path
+from textwrap import dedent
+
+path = Path("/opt/conda/envs/whisper-gui/lib/python3.10/site-packages/pyannote/audio/pipelines/speaker_verification.py")
+if path.exists():
+    text = path.read_text()
+    needle = "from speechbrain.pretrained import (\n    SpeakerRecognition,\n    EncoderClassifier,\n)"
+    if needle in text and "speechbrain.inference" not in text:
+        replacement = dedent(
+            """\
+            try:
+                from speechbrain.inference import (
+                    SpeakerRecognition,
+                    EncoderClassifier,
+                )
+            except ImportError:
+                from speechbrain.pretrained import (
+                    SpeakerRecognition,
+                    EncoderClassifier,
+                )
+            """
+        ).rstrip() + "\n"
+        text = text.replace(needle, replacement)
+        path.write_text(text)
 PY
 
 RUN git clone https://github.com/Pikurrot/whisper-gui


### PR DESCRIPTION
## Summary
- remove the incompatible conda-libmamba-solver entry point and upgrade torch/torchaudio to supported versions in the Whisper GUI image
- patch pyannote's speaker verification pipeline to prefer the new SpeechBrain inference module while keeping a fallback

## Testing
- not run (container environment lacks Docker)


------
https://chatgpt.com/codex/tasks/task_e_68df74bcd5048333a3a6b92a8c98702b