### PR TITLE
Fix Docker build failure by keeping conda solver package

### DIFF
--- a/whisper-gui/Dockerfile
+++ b/whisper-gui/Dockerfile
@@ -25,7 +25,6 @@ RUN conda create --name whisper-gui python=3.10 -y && \
     conda clean -a -y && \
     conda update -n base -c conda-forge -c pytorch conda && \
     conda config --set solver classic && \
-    conda remove -n base conda-libmamba-solver -y && \
     echo "conda activate whisper-gui" >> ~/.bashrc && \
     source /opt/conda/etc/profile.d/conda.sh && \
     conda activate whisper-gui && \


### PR DESCRIPTION
## Summary
- stop removing `conda-libmamba-solver` during the image build so the base `conda` installation remains intact

## Testing
- Not run (docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68df8a3b3e888333833189220f7845ad