### PR TITLE
Update base conda solver during Docker build

### DIFF
--- a/whisper-gui/Dockerfile
+++ b/whisper-gui/Dockerfile
@@ -23,9 +23,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
 SHELL ["bash", "-c"]
 RUN conda create --name whisper-gui python=3.10 -y && \
     conda clean -a -y && \
-    conda update -n base -c conda-forge -c pytorch conda && \
     conda config --set solver classic && \
-    conda remove -n base conda-libmamba-solver -y && \
+    conda update -n base -c conda-forge -c pytorch \
+        conda \
+        conda-libmamba-solver && \
     echo "conda activate whisper-gui" >> ~/.bashrc && \
     source /opt/conda/etc/profile.d/conda.sh && \
     conda activate whisper-gui && \


### PR DESCRIPTION
## Summary
- set the solver to classic before upgrading conda in the base environment
- update conda and conda-libmamba-solver together to keep the entry point compatible

## Testing
- Not run (docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68df8a3b3e888333833189220f7845ad